### PR TITLE
update to clojure 1.10 and new async. also nippy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 Nippy is used internally to serialize values in memcache. full.cache 1.0.1 is
 using nippy `2.10.0`, full.cache `1.1.0` is using nippy `2.13.0`.
+full.cache `1.2.0` is using nippy `2.14.0` and prefixes cache keys with `n2.14.0-`
 
 ## Configuration
 

--- a/project.clj
+++ b/project.clj
@@ -1,19 +1,19 @@
-(defproject fullcontact/full.cache "1.1.1"
+(defproject fullcontact/full.cache "1.2.0"
   :description "In-memory + memcache caching for Clojure with async loading."
   :url "https://github.com/fullcontact/full.cache"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
-  :dependencies [[org.clojure/clojure "1.8.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [net.jodah/expiringmap "0.4.1"]
                  [net.spy/spymemcached "2.12.2"]
-                 [com.taoensso/nippy "2.13.0"]
-                 [fullcontact/full.core "0.10.1"
+                 [com.taoensso/nippy "2.14.0"]
+                 [fullcontact/full.core "1.1.0"
                   :exclusions [org.clojure/clojurescript]]
-                 [fullcontact/full.async "0.9.0"]]
+                 [fullcontact/full.async "1.1.0"]]
   :aot :all
-  :plugins [[lein-midje "3.1.3"]]
+  :plugins [[lein-midje "3.2.2"]]
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]
@@ -22,4 +22,4 @@
                   ["change" "version" "leiningen.release/bump-version"]
                   ["vcs" "commit"]
                   ["vcs" "push"]]
-  :profiles {:dev {:dependencies [[midje "1.7.0"]]}})
+  :profiles {:dev {:dependencies [[midje "1.9.9"]]}})

--- a/src/full/cache.clj
+++ b/src/full/cache.clj
@@ -18,7 +18,7 @@
 
 ;;; ASYNC LOADING SUPPORT
 
-(defn- prefixkey [k]
+(defn prefixkey [k]
   (str "n2.14.0-" k))
 
 (defn- get-or-create-state [states k]

--- a/src/full/cache.clj
+++ b/src/full/cache.clj
@@ -18,6 +18,8 @@
 
 ;;; ASYNC LOADING SUPPORT
 
+(defn- prefixkey [k]
+  (str "n2.14.0-" k))
 
 (defn- get-or-create-state [states k]
   ; we cannot do loading directly in atom's swap function as it can be invoked multiple times with the same state
@@ -98,87 +100,93 @@
 
 (defn rget
   [k & {:keys [throw?]}]
-  (when @client
+  (let [kp (prefixkey k)]
+    (when @client
     (let [raw-v (try
-              (.get @client k)
+              (.get @client kp)
               (catch Exception e
                 (if throw?
                   (throw e)
-                  (log/warn k "not retrieved from cache due to" e))))
+                  (log/warn kp "not retrieved from cache due to" e))))
           v (try
               (and raw-v (nippy/thaw raw-v))
               (catch Exception e
                 (if throw?
                   (throw e)
-                  (log/warn "Failed to deserialize bytes for key" k))))]
+                  (log/warn "Failed to deserialize bytes for key" kp))))]
       (if v
-        (log/debug "Cache hit:" k)
-        (log/debug "Cache miss:" k))
-      v)))
+        (log/debug "Cache hit:" kp)
+        (log/debug "Cache miss:" kp))
+      v))))
 
 (defn rset
   ([k v] (rset k v 0))
   ([k v timeout & {:keys [throw?]}]
-   (when @client
+   (let [kp (prefixkey k)]
+     (when @client
      (try
-       (.set @client k timeout (nippy/freeze v))
-       (log/debug "Added to cache:" k)
+       (.set @client kp timeout (nippy/freeze v))
+       (log/debug "Added to cache:" kp)
        (catch Exception e
          (if throw?
            (throw e)
-           (log/warn k "not added to cache due to" e)))))
-   v))
+           (log/warn kp "not added to cache due to" e)))))
+   v)))
 
 (defn rtouch
   [k timeout & {:keys [throw?]}]
+  (let [kp (prefixkey k)]
   (when @client
     (try
-      (.touch @client k timeout)
-      (log/debug "Updated timeout for" k "to" timeout)
+      (.touch @client kp timeout)
+      (log/debug "Updated timeout for" kp "to" timeout)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn k "not touched due to" e))))))
+          (log/warn kp "not touched due to" e)))))))
 
 (defn radd
   ([k v] (radd k v 0))
   ([k v timeout & {:keys [throw?]}]
+   (let [kp (prefixkey k)]
    (when @client
      (try
-       (let [res (.get (.add @client k timeout (nippy/freeze v)))]
+       (let [res (.get (.add @client kp timeout (nippy/freeze v)))]
          (if res
            (do
-             (log/debug "Added to cache:" k)
+             (log/debug "Added to cache:" kp)
              v)
-           (log/debug "Already in cache:" k)))
+           (log/debug "Already in cache:" kp)))
        (catch Exception e
          (if throw?
            (throw e)
-           (log/warn k "not added to cache due to" e)))))))
+           (log/warn kp "not added to cache due to" e))))))))
 
 (defn rincr
   [k by timeout & {:keys [throw? default] :or {default 0}}]
+  (let [kp (prefixkey k)]
   (when @client
     (try
-      (let [res (.incr @client k by default timeout)]
-        (log/debug "Incremented value for" k "by:" by "to" res)
+      (let [res (.incr @client kp by default timeout)]
+        (log/debug "Incremented value for" kp "by:" by "to" res)
         res)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn k "not incremented due to" e))))))
+          (log/warn kp "not incremented due to" e)))))))
 
 (defn rdecr
   [k by timeout & {:keys [throw? default] :or {default 0}}]
-  (when @client
+  (let [kp (prefixkey k)]
+    (when @client
     (try
-      (let [res (.decr @client k by default timeout)]
-        (log/debug "Decremented value for" k "by:" by "to" res)
+      (let [res (.decr @client kp by default timeout)]
+        (log/debug "Decremented value for" kp "by:" by "to" res)
         res)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn k "not decremented due to" e))))))
+          (log/warn kp "not decremented due to" e)))))))
 
 (defn radd-or-get
   ([k v] (radd-or-get k v 0))
@@ -188,14 +196,15 @@
 
 (defn rdelete
   [k & {:keys [throw?]}]
-  (when @client
+  (let [kp (prefixkey k)]
+    (when @client
     (try
-      (.delete @client k)
-      (log/debug "Deleted from cache:" k)
+      (.delete @client kp)
+      (log/debug "Deleted from cache:" kp)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn k "not deleted from cache due to" e))))))
+          (log/warn kp "not deleted from cache due to" e)))))))
 
 (defn rget-or-load
   ([k loader] (rget-or-load k loader 0))

--- a/src/full/cache.clj
+++ b/src/full/cache.clj
@@ -100,14 +100,14 @@
 
 (defn rget
   [k & {:keys [throw?]}]
-  (let [kp (prefixkey k)]
-    (when @client
-    (let [raw-v (try
-              (.get @client kp)
-              (catch Exception e
-                (if throw?
-                  (throw e)
-                  (log/warn kp "not retrieved from cache due to" e))))
+  (when @client
+    (let [kp (prefixkey k)
+          raw-v (try
+                  (.get @client kp)
+                  (catch Exception e
+                    (if throw?
+                      (throw e)
+                      (log/warn kp "not retrieved from cache due to" e))))
           v (try
               (and raw-v (nippy/thaw raw-v))
               (catch Exception e
@@ -117,7 +117,7 @@
       (if v
         (log/debug "Cache hit:" kp)
         (log/debug "Cache miss:" kp))
-      v))))
+      v)))
 
 (defn rset
   ([k v] (rset k v 0))
@@ -148,10 +148,10 @@
 (defn radd
   ([k v] (radd k v 0))
   ([k v timeout & {:keys [throw?]}]
-   (let [kp (prefixkey k)]
    (when @client
      (try
-       (let [res (.get (.add @client kp timeout (nippy/freeze v)))]
+       (let [kp (prefixkey k)
+             res (.get (.add @client kp timeout (nippy/freeze v)))]
          (if res
            (do
              (log/debug "Added to cache:" kp)
@@ -160,33 +160,33 @@
        (catch Exception e
          (if throw?
            (throw e)
-           (log/warn kp "not added to cache due to" e))))))))
+           (log/warn kp "not added to cache due to" e)))))))
 
 (defn rincr
   [k by timeout & {:keys [throw? default] :or {default 0}}]
-  (let [kp (prefixkey k)]
   (when @client
     (try
-      (let [res (.incr @client kp by default timeout)]
+      (let [kp (prefixkey k)
+            res (.incr @client kp by default timeout)]
         (log/debug "Incremented value for" kp "by:" by "to" res)
         res)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn kp "not incremented due to" e)))))))
+          (log/warn kp "not incremented due to" e))))))
 
 (defn rdecr
   [k by timeout & {:keys [throw? default] :or {default 0}}]
-  (let [kp (prefixkey k)]
-    (when @client
+  (when @client
     (try
-      (let [res (.decr @client kp by default timeout)]
+      (let [kp (prefixkey k)
+            res (.decr @client kp by default timeout)]
         (log/debug "Decremented value for" kp "by:" by "to" res)
         res)
       (catch Exception e
         (if throw?
           (throw e)
-          (log/warn kp "not decremented due to" e)))))))
+          (log/warn kp "not decremented due to" e))))))
 
 (defn radd-or-get
   ([k v] (radd-or-get k v 0))


### PR DESCRIPTION
Since nippy upgrades break serialization we decided to prefix
the keys we store in the remote cache with the nippy version.

This way we dont load keys stored with a different serialized version of
nippy or save key/vals that might be loaded with a different version of
nippy and break